### PR TITLE
fix: avoid drag and drop when clicking in task

### DIFF
--- a/src/components/main/Task.tsx
+++ b/src/components/main/Task.tsx
@@ -122,6 +122,9 @@ const Task = (props: TaskProps): JSX.Element => {
         onDrop={(e) => onDrop(e)}
         raised={isDragging}
         key={key}
+        onClick={(event) => {
+          event.stopPropagation();
+        }}
       >
         <CardHeader
           avatar={


### PR DESCRIPTION
prevent dnd events from starting when bubbling of click events on button inside task

closes #35 